### PR TITLE
Add a GoAsync() function, so we can now use async/await happily

### DIFF
--- a/JumpKick.HttpLib/JumpKick.HttpLib.Tests/HttpTest.cs
+++ b/JumpKick.HttpLib/JumpKick.HttpLib.Tests/HttpTest.cs
@@ -97,17 +97,17 @@ namespace JumpKick.HttpLib.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(NullReferenceException))]
+        [ExpectedException(typeof(System.Net.WebException))]
         public void TestThrowsExceptionWithInvalidURL()
         {
             String httpUrl = "http://testurl.com9/testes";
             Http.Post(httpUrl).Form(new { admin = "admin", password = "password" }).OnSuccess(response =>
              {
+                 //will not enter this callback
                  if (response == null)
                  {
                      throw new NullReferenceException("null response");
                  }
-
              }).Go();
         }
 

--- a/JumpKick.HttpLib/JumpKick.HttpLib/Builder/RequestBuilder.Action.cs
+++ b/JumpKick.HttpLib/JumpKick.HttpLib/Builder/RequestBuilder.Action.cs
@@ -87,7 +87,7 @@ namespace JumpKick.HttpLib.Builder
                 FileStream fs = new FileStream(filePath, FileMode.OpenOrCreate);
                 ProgressCallbackHelper operation = result.CopyToProgress(fs,length);
                 operation.Completed += (totalbytes)=>{fs.Close();};
-
+                operation.Go();
             };
             return this;
 
@@ -105,7 +105,7 @@ namespace JumpKick.HttpLib.Builder
 
                 operation.ProgressChanged += (copied, total) => { OnProgressChanged(copied, total); };
                 operation.Completed += (totalbytes) => { fs.Close(); };
-
+                operation.Go();
             };
             return this;
 
@@ -123,7 +123,7 @@ namespace JumpKick.HttpLib.Builder
                 ProgressCallbackHelper operation = result.CopyToProgress(fs, length);
 
                 operation.Completed += (totalbytes) => { fs.Close(); onSuccess(headers); };
-
+                operation.Go();
                
             };
             return this;

--- a/JumpKick.HttpLib/JumpKick.HttpLib/Builder/RequestBuilder.Action.cs
+++ b/JumpKick.HttpLib/JumpKick.HttpLib/Builder/RequestBuilder.Action.cs
@@ -96,7 +96,7 @@ namespace JumpKick.HttpLib.Builder
                 if (headers.AllKeys.Contains("Content-Length")) { length = long.Parse(headers["Content-Length"]); }
 
                 FileInfo fi = new FileInfo(filePath);
-                if (fi.Directory.Exists)
+                if (!fi.Directory.Exists)
                 {
                     Directory.CreateDirectory(fi.Directory.FullName);
                 }

--- a/JumpKick.HttpLib/JumpKick.HttpLib/Builder/RequestBuilder.cs
+++ b/JumpKick.HttpLib/JumpKick.HttpLib/Builder/RequestBuilder.cs
@@ -47,6 +47,7 @@ namespace JumpKick.HttpLib.Builder
             
         }
 
+#if USE_SEMAPHORE_SLIM
         public async Task GoAsync(int millisecondsTimeout = -1)
         {
             /*
@@ -69,7 +70,7 @@ namespace JumpKick.HttpLib.Builder
 
             await req.GoAsync(millisecondsTimeout);
         }
-
+#endif
 
 
         public HttpVerb Method { get { return method; } }

--- a/JumpKick.HttpLib/JumpKick.HttpLib/Builder/RequestBuilder.cs
+++ b/JumpKick.HttpLib/JumpKick.HttpLib/Builder/RequestBuilder.cs
@@ -47,7 +47,28 @@ namespace JumpKick.HttpLib.Builder
             
         }
 
+        public async Task GoAsync(int millisecondsTimeout = -1)
+        {
+            /*
+             * If an actionprovider has not been set, we create one.
+             */
+            if (this.actionProvider == null)
+            {
+                this.actionProvider = new SettableActionProvider(success, fail, make);
+            }
 
+            Request req = new Request
+            {
+                Url = url,
+                Method = method,
+                Action = actionProvider,
+                Auth = authProvider,
+                Headers = headerProvider,
+                Body = bodyProvider
+            };
+
+            await req.GoAsync(millisecondsTimeout);
+        }
 
 
 

--- a/JumpKick.HttpLib/JumpKick.HttpLib/JumpKick.HttpLib.csproj
+++ b/JumpKick.HttpLib/JumpKick.HttpLib/JumpKick.HttpLib.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;USE_SEMAPHORE_SLIM</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -25,7 +25,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;USE_SEMAPHORE_SLIM</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/JumpKick.HttpLib/JumpKick.HttpLib/Request.cs
+++ b/JumpKick.HttpLib/JumpKick.HttpLib/Request.cs
@@ -159,8 +159,11 @@
             {
 #if USE_SEMAPHORE_SLIM
                 _semaphore.Release();//for GoAsync()
-#endif               
-                action.Fail(webEx);
+#endif          
+                if (action != null && action.Make != null)     
+                    action.Fail(webEx);
+                else
+                    throw webEx;//better then a null Exception
             }
         }
 
@@ -233,7 +236,10 @@
                 }
                 catch (WebException webEx)
                 {
-                    fail(webEx);
+                    if (fail != null)   
+                        fail(webEx);
+                    else
+                        throw webEx;//better then a null Exception
                 }
                 finally
                 {

--- a/JumpKick.HttpLib/JumpKick.HttpLib/Request.cs
+++ b/JumpKick.HttpLib/JumpKick.HttpLib/Request.cs
@@ -160,7 +160,7 @@
 #if USE_SEMAPHORE_SLIM
                 _semaphore.Release();//for GoAsync()
 #endif          
-                if (action != null && action.Make != null)     
+                if (action != null && action.Fail != null)     
                     action.Fail(webEx);
                 else
                     throw webEx;//better then a null Exception

--- a/JumpKick.HttpLib/JumpKick.HttpLib/Request.cs
+++ b/JumpKick.HttpLib/JumpKick.HttpLib/Request.cs
@@ -18,10 +18,12 @@
 
         protected ActionProvider action;
 
+#if USE_SEMAPHORE_SLIM
         /// <summary>
         /// Using for GoAsync() to await.
         /// </summary>
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(0);
+#endif
 
         public Request()
         {
@@ -107,11 +109,13 @@
             MakeRequest();
         }
 
+#if USE_SEMAPHORE_SLIM
         public async Task GoAsync(int millisecondsTimeout)
         {
             MakeRequest();
             await _semaphore.WaitAsync(millisecondsTimeout);
         }
+#endif
 
         protected virtual HttpWebRequest GetWebRequest(string url)
         {
@@ -153,7 +157,9 @@
             }
             catch (WebException webEx)
             {
+#if USE_SEMAPHORE_SLIM
                 _semaphore.Release();//for GoAsync()
+#endif               
                 action.Fail(webEx);
             }
         }
@@ -231,7 +237,9 @@
                 }
                 finally
                 {
+#if USE_SEMAPHORE_SLIM
                     _semaphore.Release();//for GoAsync()
+#endif
                 }               
             });
         }


### PR DESCRIPTION
can use "async/await" simply like this. I often use this method to write C# now, it may be useful.

```` C#
        private async void DoSomething()
        {
            //thing1
            await Http.Get("https://bing.com").OnSuccess((text) =>{
                //do thing "success";
            }).OnFail((e) => {
                //do thing "fail";
            }).GoAsync();

            //when the thing1 "success" or "fail" has done ,execute the following
            //thing2
            await Http.Get("https://bing.com").OnSuccess((text) => {
                //do thing "success";
            }).OnFail((e) => {
                //do thing "fail";
            }).GoAsync();

            //...
        }
````