### PR TITLE
OnFail not set will throw NullReferenceException

### DIFF
--- a/JumpKick.HttpLib/JumpKick.HttpLib.Tests/HttpTest.cs
+++ b/JumpKick.HttpLib/JumpKick.HttpLib.Tests/HttpTest.cs
@@ -96,7 +96,7 @@ namespace JumpKick.HttpLib.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(NullReferenceException))]
+        [ExpectedException(typeof(System.Net.WebException))]
         public void TestThrowsExceptionWithInvalidURL()
         {
             String httpUrl = "http://testurl.com9/testes";
@@ -104,7 +104,7 @@ namespace JumpKick.HttpLib.Tests
              {
                  if(response==null)
                  {
-                     throw new NullReferenceException("null response");
+                     throw new System.Net.WebException("null response");
                  }
 
              }).Go();

--- a/JumpKick.HttpLib/JumpKick.HttpLib/Provider/SettableActionProvider.cs
+++ b/JumpKick.HttpLib/JumpKick.HttpLib/Provider/SettableActionProvider.cs
@@ -17,6 +17,10 @@ namespace JumpKick.HttpLib.Provider
 
         public SettableActionProvider(Action<WebHeaderCollection, Stream> success, Action<WebException> fail, Action<HttpWebRequest> make = null)
         {
+            this.make = make;
+            this.success = success;
+            this.fail = fail;
+
             if (success == null)
             {
                 this.success = nonaction.Success;
@@ -31,10 +35,6 @@ namespace JumpKick.HttpLib.Provider
             {
                 this.make = nonaction.Make;
             }
-
-            this.make = make;
-            this.success = success;
-            this.fail = fail;
         }
 
         public Action<WebHeaderCollection, Stream> Success


### PR DESCRIPTION
Hi   @j6mes ,

When I use the following code, if the url is invalid and OnFail method is not called, it occured throw NullReferenceException.

       Http.Get("https://jthorne.co.uk/httplib")
       .OnSuccess(result =>
       {
           Console.Write(result);
       }).Go();

I try to resolve it and find the following way can do it.


I hope this is usefully.

Thanks.



